### PR TITLE
[21 pontos] Tornar logotipo do rodapé clicável com redirecionamento para Home

### DIFF
--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -31,7 +31,9 @@ const Footer = () => {
 
           <div>
             <div className="flex items-center space-x-2 mb-4 ">
-              <img className='h-16' src={logotipo} alt="logotipo" />
+              <Link to="/" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
+                <img className='h-16' src={logotipo} alt="logotipo" />
+              </Link>
             </div>
             <p className="text-cinza mb-4">
               Uma plataforma para cidadãos reportarem problemas urbanos e


### PR DESCRIPTION
### 📌 [Rodapé] Tornar logotipo do rodapé clicável com redirecionamento para Home (21 pontos)

### 🧩 Descrição  
O logotipo presente no rodapé não possui comportamento interativo. Esta melhoria adiciona redirecionamento para a **página inicial** ao clicar no logo, conforme padrão de usabilidade.

### 🎯 Objetivo  
- Reforçar o padrão de navegação comum.  
- Aplicar a heurística de **consistência e padronização**.  
- Facilitar o retorno à página principal.

### 📊 Pontuação: 21 pontos

### 🌱 Branch: `feature/logo-footer-link-home`
