### PR TITLE
[21 pontos] Adicionar scroll automático ao topo ao navegar via footer

### DIFF
--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -17,14 +17,16 @@ import AccessDeniedPage from "../pages/AccessDeniedPage"
 import AdminRoute from "./AdminRoute";
 import AdminDashboardPage from "../pages/AdminDashboardPage";
 import UsersAdminPage from "../pages/UsersAdminPage";
+import ScrollToTop from "@/utils/ScrollToTop";
 
 export default function AppRoutes() {
   return (
-    <BrowserRouter>
+    <BrowserRouter>    
       <ToastProvider>
+        <ScrollToTop />
         <Toaster />
         <Routes>
-  
+        
           {/* rotas publicas */}
   
           <Route path="/" element={<Index />} />

--- a/frontend/src/utils/ScrollToTop.jsx
+++ b/frontend/src/utils/ScrollToTop.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+    const {pathname} = useLocation()
+
+    useEffect (() => {
+        window.scrollTo({
+            top: 0,
+            left: 0,
+            behavior: 'smooth'
+
+        })
+    }, [pathname])
+
+    return null
+
+}
+export default ScrollToTop


### PR DESCRIPTION
### 📌 [Footer] Adicionar scroll automático ao topo ao navegar via footer (21 pontos)

### 🧩 Descrição  
Ao clicar em links no rodapé, algumas páginas carregam com o scroll mantido no meio ou final da tela. Esta melhoria garante que **toda navegação via footer** leve o usuário ao **topo da nova página** automaticamente.

### 🎯 Objetivo  
- Garantir uma navegação fluida e previsível.  
- Aplicar a heurística de **eficiência e flexibilidade**.  
- Corrigir inconsistências na experiência de navegação.

### 📊 Pontuação: 21 pontos

### 🌱 Branch: `feature/footer-scroll-top`
