### PR TITLE
Correção de Conflito entre Páginação e Filtros de Denúncias

### DIFF
--- a/frontend/src/components/denuncias/DenunciasList.jsx
+++ b/frontend/src/components/denuncias/DenunciasList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import DenunciaCard from "./CardDenuncia";
 import { Input } from "@/components/ui/input";
 import {
@@ -17,87 +17,24 @@ import {
   PaginationPrevious,
   PaginationLink,
 } from "@/components/ui/pagination";
-import { useReport } from "@/hooks/useReport";
+import { useFilteredPaginatedReports } from "@/hooks/useFilteredPaginatedReports";
 
 const ITEMS_PER_PAGE = 6;
-const SEARCH_ITEMS_LIMIT = 7
 
 const DenunciasList = () => {
-  const { getInitialReports, getMoreReports, loading } = useReport();
-
-  const [denuncias, setDenuncias] = useState([]);
-  const [lastVisible, setLastVisible] = useState(null);
-  const [pageHistory, setPageHistory] = useState([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [filter, setFilter] = useState("todas");
 
-  // Carregar as denúncias iniciais
-  useEffect(() => {
-    const fetchData = async () => {
-      const {verify, reports, lastVisible } = await getInitialReports(SEARCH_ITEMS_LIMIT, ITEMS_PER_PAGE);
-      setDenuncias(reports);
-      setLastVisible(lastVisible);
-      setPageHistory([]);
-      setCurrentPage(1); // reinicia página
-      setHasMore(verify.length > ITEMS_PER_PAGE);
-    };
-
-    fetchData();
-  }, []);
-
-  // Carregar mais denúncias
-  const handleLoadMore = async () => {
-    if (!lastVisible || !hasMore) return;
-
-    const {verify: moreVerify, reports: more, lastVisible: newLast } = await getMoreReports(
-      lastVisible,
-      SEARCH_ITEMS_LIMIT,
-      ITEMS_PER_PAGE
-    );
-
-    setPageHistory((prev) => [...prev, {      
-      lastVisible: lastVisible
-    }]);
-    setDenuncias(more);
-    setLastVisible(newLast);
-    setCurrentPage((prev) => prev + 1); // avança página
-    setHasMore(moreVerify.length > ITEMS_PER_PAGE);
-  };
-
-  // Carregar a página anterior
-  const handlePreviousPage = async () => {
-    if (pageHistory.length === 0) return;
-    
-    const newHistory = [...pageHistory];
-    const previousDoc = newHistory[newHistory.length - 2]?.lastVisible ?? null;
-
-    const {reports: previousReports, lastVisible: newLast } = previousDoc
-      ? await getMoreReports(previousDoc, SEARCH_ITEMS_LIMIT, ITEMS_PER_PAGE)
-      : await getInitialReports(SEARCH_ITEMS_LIMIT, ITEMS_PER_PAGE);
-
-    setDenuncias(previousReports);
-    setLastVisible(newLast);
-    setPageHistory(newHistory.slice(0, -1));
-    setCurrentPage((prev) => Math.max(prev - 1, 1)); // volta página
-    setHasMore(true);
-  };
-
-  // Filtrando as denúncias
-  const filteredDenuncias = denuncias.filter((denuncia) => {
-    // Comparando título, descrição e local com o termo de pesquisa
-    const matchesSearch =
-      (denuncia.title || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (denuncia.description || "")
-        .toLowerCase()
-        .includes(searchTerm.toLowerCase()) ||
-      (denuncia.location?.address || "").toLowerCase().includes(searchTerm.toLowerCase());
-
-    // Filtrando pelas categorias de status
-    const matchesFilter = filter === "todas" || denuncia.status === filter;
-
-    return matchesSearch && matchesFilter;
+  const {
+    paginatedReports,
+    currentPage,
+    totalPages,
+    setCurrentPage,
+    totalItems,
+  } = useFilteredPaginatedReports({
+    searchTerm,
+    statusFilter: filter,
+    itemsPerPage: ITEMS_PER_PAGE,
   });
 
   return (
@@ -126,14 +63,14 @@ const DenunciasList = () => {
         </Select>
       </div>
 
-      {filteredDenuncias.length === 0 ? (
+      {paginatedReports.length === 0 ? (
         <div className="text-center py-10 text-muted-foreground">
           <p>Nenhuma denúncia encontrada.</p>
         </div>
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredDenuncias.map((denuncia) => (
+            {paginatedReports.map((denuncia) => (
               <DenunciaCard key={denuncia.reportId} denuncia={denuncia} />
             ))}
           </div>
@@ -142,36 +79,26 @@ const DenunciasList = () => {
             <PaginationContent>
               <PaginationItem>
                 <PaginationPrevious
-                  onClick={handlePreviousPage}
-                  className={pageHistory.length === 0 || loading ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                  onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+                  className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
                 />
               </PaginationItem>
 
-              {/* Exibe até 2 páginas anteriores */}
-              {currentPage > 2 && (
-                <PaginationItem>
-                  <PaginationLink onClick={() => handlePreviousPage()}>
-                    {currentPage - 2}
-                  </PaginationLink>
-                </PaginationItem>
-              )}
               {currentPage > 1 && (
                 <PaginationItem>
-                  <PaginationLink onClick={() => handlePreviousPage()}>
+                  <PaginationLink onClick={() => setCurrentPage(currentPage - 1)}>
                     {currentPage - 1}
                   </PaginationLink>
                 </PaginationItem>
               )}
 
-              {/* Página atual */}
               <PaginationItem>
                 <PaginationLink isActive>{currentPage}</PaginationLink>
               </PaginationItem>
 
-              {/* Próximas páginas (opcional, depende de hasMore) */}
-              {hasMore && (
+              {currentPage < totalPages && (
                 <PaginationItem>
-                  <PaginationLink onClick={() => handleLoadMore()}>
+                  <PaginationLink onClick={() => setCurrentPage(currentPage + 1)}>
                     {currentPage + 1}
                   </PaginationLink>
                 </PaginationItem>
@@ -179,8 +106,8 @@ const DenunciasList = () => {
 
               <PaginationItem>
                 <PaginationNext
-                  onClick={handleLoadMore}
-                  className={!hasMore || loading ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                  onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
+                  className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
                 />
               </PaginationItem>
             </PaginationContent>

--- a/frontend/src/hooks/useFilteredPaginatedReports.jsx
+++ b/frontend/src/hooks/useFilteredPaginatedReports.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from "react";
+import { useReport } from "@/hooks/useReport";
+
+export function useFilteredPaginatedReports({
+  itemsPerPage = 6,
+  debounceDelay = 400,
+  searchTerm,
+  statusFilter,
+}) {
+  const { getAllReports } = useReport();
+  const [allReports, setAllReports] = useState([]);
+  const [filteredReports, setFilteredReports] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
+
+  // Debounce da busca
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSearch(searchTerm);
+    }, debounceDelay);
+
+    return () => clearTimeout(handler);
+  }, [searchTerm, debounceDelay]);
+
+  // Buscar todas as denúncias
+  useEffect(() => {
+    async function fetchReports() {
+      const rawReports = await getAllReports();
+      setAllReports(rawReports);
+    }
+    fetchReports();
+  }, []);
+
+  // Aplicar filtros
+  useEffect(() => {
+    const filtered = allReports.filter((report) => {
+      const matchesSearch =
+        (report.title || "").toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+        (report.description || "").toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+        (report.location?.address || "").toLowerCase().includes(debouncedSearch.toLowerCase());
+
+      const matchesStatus =
+        statusFilter === "todas" || report.status === statusFilter;
+
+      return matchesSearch && matchesStatus;
+    });
+
+    setFilteredReports(filtered);
+    setCurrentPage(1); // Reinicia a página ao mudar filtro
+  }, [allReports, debouncedSearch, statusFilter]);
+
+  // Paginação local
+  const paginatedReports = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    return filteredReports.slice(start, start + itemsPerPage);
+  }, [filteredReports, currentPage, itemsPerPage]);
+
+  const totalPages = Math.ceil(filteredReports.length / itemsPerPage);
+
+  return {
+    paginatedReports,
+    currentPage,
+    totalPages,
+    setCurrentPage,
+    totalItems: filteredReports.length,
+  };
+}


### PR DESCRIPTION

### 🔧 Refatoração de Filtros e Paginação de Denúncias

Este PR introduz o novo hook `useFilteredPaginatedReports`, criado para resolver um problema crítico na lógica de filtros e paginação do componente `DenunciasList`.

#### 🧠 Motivação

Anteriormente, os filtros eram aplicados **após** a paginação, o que causava inconsistências: denúncias que deveriam aparecer na primeira página eram ocultadas por estarem em páginas posteriores. Isso comprometia a experiência do usuário e a integridade dos dados exibidos.

#### ✨ O que o novo hook faz

O hook `useFilteredPaginatedReports` centraliza a lógica de:

-   Busca textual com debounce
    
-   Filtros por status
    
-   Paginação local sobre os dados já filtrados
    

Ele utiliza a função `getAllReports` para obter o conjunto completo de denúncias e aplica os filtros **antes** de paginar, garantindo que os dados exibidos estejam sempre corretos e consistentes.

#### 🌀 O que é debounce?

Debounce é uma técnica usada para **evitar chamadas excessivas** a uma função enquanto o usuário está digitando. No contexto da busca, isso significa que o sistema **espera alguns milissegundos após o último caractere digitado** antes de aplicar o filtro. Isso melhora a performance e evita que o hook seja executado a cada tecla pressionada.

#### 🛠️ Alterações no componente `DenunciasList`

-   Remoção da lógica de paginação baseada em `getInitialReports` e `getMoreReports`
    
-   Substituição por `useFilteredPaginatedReports`, que agora controla os dados exibidos, a página atual e o total de páginas
    
-   Simplificação da navegação entre páginas, agora baseada em controle local (`setCurrentPage`)
    
-   Melhoria na UX com busca reativa e filtros mais precisos

#### 📌 Observações

-   As funções `getInitialReports` e `getMoreReports` continuam disponíveis no hook `useReport`, mas devem ser utilizadas apenas em contextos onde **não há necessidade de filtros complexos**, como páginas públicas com navegação simples.
    
-   O novo hook `useFilteredPaginatedReports` é recomendado para páginas que exigem **busca textual**, **filtros dinâmicos** e **controle local de paginação**, como:
    
    -   Listagem geral de denúncias
        
    -   Minhas denúncias (perfil do usuário)
        
    -   Denúncias salvas ou favoritas
        
-   A função `getAllReports` é utilizada como base para o novo hook e pode ser reaproveitada em outros contextos, inclusive com suporte a `userId` para filtragem por usuário.
    
-   O uso de debounce na busca melhora a performance e evita chamadas desnecessárias durante a digitação, tornando a experiência mais fluida. 

### 📸Prints de Evidência

-   Visualização das Denuncias normal, sem nenhum Filtro
<img width="770" height="494" alt="image" src="https://github.com/user-attachments/assets/a9667db7-a8d2-4352-855a-819adcd9cf62" />

-   Visualização com Filtro de Pendentes (as 2 denuncias, originalmente estavam em páginas diferentes)
<img width="773" height="298" alt="image" src="https://github.com/user-attachments/assets/7cd67965-1e2a-4092-be67-569a3b2c4b75" />

-   Filtro das Denuncias Resolvidas com 2 páginas
<img width="783" height="510" alt="image" src="https://github.com/user-attachments/assets/2988f41c-2550-4092-b1c1-fa060943a56f" />
<img width="769" height="289" alt="image" src="https://github.com/user-attachments/assets/610c3b1b-8b1d-4458-9f3d-8fc79e0fadb2" />

-   Filtro por Nome das denuncias
<img width="763" height="289" alt="image" src="https://github.com/user-attachments/assets/d96843ef-3e16-44c3-89a7-7971046c20f2" />

