### PR TITLE
[2 pontos] Inserir informação sobre uso de dados na seção de dúvidas

### DIFF
--- a/frontend/src/data/faqData.jsx
+++ b/frontend/src/data/faqData.jsx
@@ -23,6 +23,12 @@ export const faqCategories = [
         answer:
           "Não! O Cidade Integra é uma plataforma totalmente gratuita para todos os cidadãos. Nosso objetivo é facilitar a comunicação entre a população e os órgãos públicos responsáveis por solucionar os problemas reportados.",
       },
+      {
+        id: "item-4",
+        question: "Como o Cidade Integra lida com as minhas informações?",
+        answer:
+            "No Cidade Integra, levamos a sua privacidade a sério. As informações que você compartilha como nome, e-mail, localização e fotos dos problemas reportados são utilizadas exclusivamente para encaminhar suas denúncias aos órgãos competentes, manter você informado sobre o andamento e melhorar continuamente a plataforma.",
+      },
     ],
   },
   {


### PR DESCRIPTION
Nome da issue: [Legal/Aviso 2 pontos] Inserir informação sobre uso de dados na seção de dúvidas
🧩 Descrição
A seção de dúvidas frequentes não contém informações claras sobre o uso dos dados pessoais dos usuários, o que pode gerar insegurança e descumprimento da LGPD.

Será inserido um aviso ou link sobre a Política de Privacidade e tratamento de dados.

🎯 Objetivo
Aumentar transparência com os usuários.
Estar em conformidade com a LGPD.
📊 Pontuação: 2 pontos
🌱 Branch: feature/lgpd-info-faq