### PR TITLE
Corrigir redirecionamento de “Esqueceu a senha”

### DIFF
--- a/frontend/src/data/faqData.jsx
+++ b/frontend/src/data/faqData.jsx
@@ -135,7 +135,7 @@ export const faqCategories = [
             </Link>{" "}
             e depois na opção{" "}
             <Link
-              to="/login"
+              to="/recuperar-senha"
               className="text-verde font-bold hover:text-verde-escuro hover:underline"
             >
               Esqueceu a senha?


### PR DESCRIPTION
#### 🧩 Descrição

O link “Esqueceu a senha” redireciona para “Entrar” em vez de para `/recuperar-senha`.

#### 🎯 Objetivo

-   Corrigir redirecionamento para a rota correta.
    

#### 📊 Pontuação: 1 ponto

#### 🌱 Branch: `fix/forgot-password-redirect`
---
<img width="932" height="272" alt="image" src="https://github.com/user-attachments/assets/ed9be61f-59f6-4c64-bdbb-5c9060007f3d" />
