### PR TITLE
fix: remoção do ícone das páginas "dúvidas" e "admin"

### DIFF
--- a/frontend/src/components/faq/FAQHeader.jsx
+++ b/frontend/src/components/faq/FAQHeader.jsx
@@ -7,7 +7,6 @@ const FAQHeader = () => {
     <header className="bg-azul text-white py-12">
       <div className="container mx-auto px-4">
         <h1 className="text-3xl font-bold mb-4 flex items-center gap-2">
-          <BookOpen className="h-7 w-7" />
           Perguntas Frequentes
         </h1>
         <p className="text-lg text-cinza">

--- a/frontend/src/pages/AdminDashboardPage.jsx
+++ b/frontend/src/pages/AdminDashboardPage.jsx
@@ -14,7 +14,6 @@ const AdminDashboardPage = () => {
         <div className="bg-azul text-white py-12">
           <div className="container mx-auto px-4">
             <div className="flex items-center gap-2">
-              <Shield className="h-6 w-6 text-verde" />
               <h1 className="text-3xl font-bold">Painel de Administração</h1>
             </div>
             <p className="text-lg text-cinza mt-2">


### PR DESCRIPTION
### 🟢 [UI 1 ponto] Padronizar ícones de títulos

#### 🧩 Descrição

O título “Denúncias” não possui ícone, enquanto “Dúvidas Frequentes” possui.

#### 🎯 Objetivo

-   Remover ícones dos títulos “Perguntas Frequentes” e “Painel de Administração”.
    
#### 📊 Pontuação: 1 ponto

#### 🌱 Branch: `style/title-icons`
