### PR TITLE
[BUG 2 pontos] Corrigir exibição dupla de badges no perfil

### DIFF
--- a/frontend/src/components/perfil/BadgesDisplay.jsx
+++ b/frontend/src/components/perfil/BadgesDisplay.jsx
@@ -5,17 +5,12 @@ const BadgesDisplay = ({ user }) => {
 
   if (badges.length === 0) return null
 
+  const lastBadge = badges[badges.length - 1]
+
   return (
-    <>
-      {badges.map((badge) => (
-        <span
-          key={badge.id}
-          className="font-semibold"
-        >
-          {badge.label}
-        </span>
-      ))}
-    </>
+    <span className="font-semibold">
+      {lastBadge.label}
+    </span>
   )
 }
 


### PR DESCRIPTION
### 🟡 [BUG 2 pontos] Corrigir exibição dupla de badges no perfil

#### 🧩 Descrição

O perfil do usuário pode exibir duas badges simultaneamente incorretamente.

#### 🎯 Objetivo

-   Exibir apenas uma badge ativa por vez.

#### 📊 Pontuação: 2 pontos

#### 🌱 Branch: `fix/duplicate-badges`